### PR TITLE
[task] - Update Travis/CI process to use supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - mongodb
   - docker
 node_js:
-  - "4.4.3"
-  - "6.9.1"
+  - 4
+  - 6
 before_install:
   - npm install fh-build -g
   - fh-build template


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20307

## WHAT
* Update to use NodeJS version to use 4, 6

PS: It is not unable to working with NodeJS 8. 

## WHY
The Travis/CI should use the currently supported versions in order to validate the PRs.

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 